### PR TITLE
Use default value of T in ExecuteScalar when column type is Null

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -1974,7 +1974,9 @@ namespace SQLite
                 var r = SQLite3.Step (stmt);
                 if (r == SQLite3.Result.Row) {
                     var colType = SQLite3.ColumnType (stmt, 0);
-                    val = (T)ReadCol (stmt, 0, colType, typeof(T));
+                    if (colType != SQLite3.ColType.Null) {
+                        val = (T)ReadCol (stmt, 0, colType, typeof(T));
+                    }
                 }
                 else if (r == SQLite3.Result.Done) {
                 }


### PR DESCRIPTION
When executing a SUM query the ExecuteScalar method throws NullReferenceException if the table is empty or no rows were selected by the WHERE clause or similar. In these cases SQLite3.ColumnType returns ColType.Null, ReadCol returns null, and the attempted cast to T throws the exception.

This fixes praeclarum/sqlite-net#171.
